### PR TITLE
Allow surface editor zones to store polygon points

### DIFF
--- a/colour-simulator/angular.json
+++ b/colour-simulator/angular.json
@@ -79,5 +79,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/colour-simulator/src/app/app.module.ts
+++ b/colour-simulator/src/app/app.module.ts
@@ -13,6 +13,7 @@ import { SurfaceViewerComponent } from './components/surface-viewer/surface-view
 import { RouterModule } from '@angular/router';
 import { ColourCardComponent } from './components/colour-card/colour-card.component';
 import { SurfaceLegendComponent } from './components/surface-legend/surface-legend.component';
+import { SurfaceEditorComponent } from './components/surface-editor/surface-editor.component';
 
 @NgModule({
   declarations: [
@@ -23,7 +24,8 @@ import { SurfaceLegendComponent } from './components/surface-legend/surface-lege
     PalettePanelComponent,
     SurfaceViewerComponent,
     ColourCardComponent,
-    SurfaceLegendComponent
+    SurfaceLegendComponent,
+    SurfaceEditorComponent
   ],
   imports: [
     BrowserModule,

--- a/colour-simulator/src/app/components/simulator/simulator.component.html
+++ b/colour-simulator/src/app/components/simulator/simulator.component.html
@@ -9,5 +9,6 @@
   <div class="simulator__canvas">
     <app-surface-viewer [surface]="vm.surface" [selectedColours]="vm.selectedColours"></app-surface-viewer>
     <app-palette-panel [surface]="vm.surface" [selectedColours]="vm.selectedColours"></app-palette-panel>
+    <app-surface-editor></app-surface-editor>
   </div>
 </section>

--- a/colour-simulator/src/app/components/surface-editor/surface-editor.component.css
+++ b/colour-simulator/src/app/components/surface-editor/surface-editor.component.css
@@ -1,0 +1,177 @@
+.surface-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  background-color: #ffffff;
+  border-radius: 1rem;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.08);
+}
+
+.surface-editor__header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  color: #1f2937;
+}
+
+.surface-editor__header p {
+  margin: 0.25rem 0 0;
+  color: #4b5563;
+}
+
+.surface-editor__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.surface-editor__controls button {
+  padding: 0.6rem 1rem;
+  border: none;
+  border-radius: 0.75rem;
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: #fff;
+  cursor: pointer;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.surface-editor__controls button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+  box-shadow: none;
+  background: #cbd5f5;
+}
+
+.surface-editor__controls button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 20px rgba(37, 99, 235, 0.2);
+}
+
+.surface-editor__controls .danger {
+  background: linear-gradient(135deg, #ef4444, #dc2626);
+}
+
+.file-input {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.6rem 1rem;
+  background: #f3f4f6;
+  border-radius: 0.75rem;
+  cursor: pointer;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.file-input input[type='file'] {
+  opacity: 0;
+  position: absolute;
+  inset: 0;
+  cursor: pointer;
+}
+
+.surface-editor__filename {
+  font-size: 0.9rem;
+  color: #1f2937;
+}
+
+.surface-editor__warning {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background: #fef3c7;
+  color: #92400e;
+  border: 1px solid #f59e0b;
+}
+
+.surface-editor__workspace {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.surface-editor__workspace canvas {
+  width: 100%;
+  min-height: 300px;
+  border-radius: 0.75rem;
+  border: 1px solid #d1d5db;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.05);
+}
+
+.surface-editor__zones {
+  background: #f9fafb;
+  border-radius: 0.75rem;
+  padding: 1rem;
+}
+
+.surface-editor__zones h3 {
+  margin: 0 0 0.75rem;
+  font-size: 1.1rem;
+  color: #1f2937;
+}
+
+.surface-editor__zones ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.surface-editor__zones li {
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  box-shadow: 0 10px 20px rgba(148, 163, 184, 0.12);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.surface-editor__zones li.is-active {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}
+
+.surface-editor__zones button {
+  justify-self: start;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: none;
+  background: #e0e7ff;
+  color: #312e81;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.surface-editor__zones label {
+  display: grid;
+  gap: 0.25rem;
+  font-size: 0.85rem;
+  color: #4b5563;
+}
+
+.surface-editor__zones input[type='text'] {
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid #cbd5f5;
+  font-size: 0.95rem;
+}
+
+.zone-meta {
+  font-size: 0.8rem;
+  color: #6b7280;
+}
+
+.zone-meta span {
+  display: inline-block;
+  margin-right: 0.25rem;
+}
+
+@media (min-width: 1024px) {
+  .surface-editor__workspace {
+    grid-template-columns: 2fr 1fr;
+    align-items: start;
+  }
+}

--- a/colour-simulator/src/app/components/surface-editor/surface-editor.component.html
+++ b/colour-simulator/src/app/components/surface-editor/surface-editor.component.html
@@ -1,0 +1,42 @@
+<section class="surface-editor">
+  <header class="surface-editor__header">
+    <h2>Éditeur de surface</h2>
+    <p>Téléchargez une image et ajoutez des zones interactives pour votre projet.</p>
+  </header>
+
+  <div class="surface-editor__controls">
+    <label class="file-input">
+      <span class="file-input__label">Choisir une image</span>
+      <input type="file" accept="image/*" (change)="onFileSelected($event)" />
+    </label>
+    <button type="button" (click)="addPolygonZone()" [disabled]="!isCanvasReady">Ajouter une zone</button>
+    <button type="button" class="danger" (click)="removeSelectedZone()" [disabled]="!selectedZoneId">Supprimer la zone sélectionnée</button>
+    <span class="surface-editor__filename" *ngIf="backgroundName">Image : {{ backgroundName }}</span>
+  </div>
+
+  <p *ngIf="fabricUnavailable" class="surface-editor__warning">
+    Fabric.js n'a pas pu être chargé. Vérifiez votre connexion réseau ou ajoutez la bibliothèque au projet pour activer l'éditeur.
+  </p>
+
+  <div class="surface-editor__workspace" *ngIf="!fabricUnavailable">
+    <canvas #canvasEl></canvas>
+    <aside class="surface-editor__zones" *ngIf="zones.length">
+      <h3>Zones définies</h3>
+      <ul>
+        <li *ngFor="let zone of zones" [class.is-active]="zone.id === selectedZoneId">
+          <button type="button" (click)="selectZone(zone)">{{ zone.label }}</button>
+          <label>
+            Nom
+            <input type="text" [(ngModel)]="zone.label" (ngModelChange)="onZoneLabelChange(zone)" />
+          </label>
+          <div class="zone-meta">
+            Points :
+            <span *ngFor="let point of zone.points; let i = index">
+              ({{ point.x }}, {{ point.y }})<span *ngIf="i < zone.points.length - 1"> ·</span>
+            </span>
+          </div>
+        </li>
+      </ul>
+    </aside>
+  </div>
+</section>

--- a/colour-simulator/src/app/components/surface-editor/surface-editor.component.ts
+++ b/colour-simulator/src/app/components/surface-editor/surface-editor.component.ts
@@ -1,0 +1,240 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewChild } from '@angular/core';
+
+declare const fabric: any;
+
+interface SurfacePoint {
+  x: number;
+  y: number;
+}
+
+interface SurfaceZone {
+  id: string;
+  label: string;
+  points: SurfacePoint[];
+}
+
+@Component({
+  selector: 'app-surface-editor',
+  templateUrl: './surface-editor.component.html',
+  styleUrls: ['./surface-editor.component.css']
+})
+export class SurfaceEditorComponent implements AfterViewInit, OnDestroy {
+  @ViewChild('canvasEl', { static: true }) canvasRef!: ElementRef<HTMLCanvasElement>;
+
+  zones: SurfaceZone[] = [];
+  private canvas?: any;
+  private nextZoneIndex = 1;
+  selectedZoneId: string | null = null;
+  backgroundName = '';
+  fabricUnavailable = false;
+
+  ngAfterViewInit(): void {
+    if (typeof fabric === 'undefined') {
+      this.fabricUnavailable = true;
+      return;
+    }
+
+    this.canvas = new fabric.Canvas(this.canvasRef.nativeElement, {
+      selection: true,
+      preserveObjectStacking: true
+    });
+
+    this.canvas.on('object:modified', () => this.syncZonesFromCanvas());
+    this.canvas.on('object:moving', () => this.syncZonesFromCanvas());
+    this.canvas.on('object:scaling', () => this.syncZonesFromCanvas());
+    this.canvas.on('selection:created', (event: any) => this.onSelection(event));
+    this.canvas.on('selection:updated', (event: any) => this.onSelection(event));
+    this.canvas.on('selection:cleared', () => (this.selectedZoneId = null));
+    this.canvas.on('object:added', (event: any) => {
+      const target = event?.target;
+      if (target?.type === 'polygon' && !target.controls?.p0) {
+        this.makePolygonEditable(target);
+      }
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.canvas?.dispose();
+  }
+
+  get isCanvasReady(): boolean {
+    return !!this.canvas;
+  }
+
+  onFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    if (!input.files || input.files.length === 0) {
+      return;
+    }
+
+    const file = input.files[0];
+    this.backgroundName = file.name;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const dataUrl = reader.result as string;
+      fabric.Image.fromURL(dataUrl, (img: any) => {
+        const width = img.width ?? 800;
+        const height = img.height ?? 500;
+        this.canvas.setDimensions({ width, height });
+        this.canvas.setBackgroundImage(img, this.canvas.renderAll.bind(this.canvas), {
+          scaleX: width / (img.width || width),
+          scaleY: height / (img.height || height)
+        });
+      }, { crossOrigin: 'anonymous' });
+    };
+    reader.readAsDataURL(file);
+  }
+
+  addPolygonZone(): void {
+    if (!this.canvas) {
+      return;
+    }
+
+    const zoneId = `zone-${this.nextZoneIndex++}`;
+    const points = [
+      { x: 100, y: 100 },
+      { x: 260, y: 100 },
+      { x: 260, y: 200 },
+      { x: 100, y: 200 }
+    ];
+
+    const polygon = new fabric.Polygon(points, {
+      fill: 'rgba(0, 153, 255, 0.25)',
+      stroke: '#0099ff',
+      strokeWidth: 2,
+      perPixelTargetFind: true,
+      objectCaching: false,
+      cornerSize: 8,
+      transparentCorners: false,
+      lockRotation: true,
+      lockScalingFlip: true,
+      lockScalingX: true,
+      lockScalingY: true
+    });
+
+    polygon.set('zoneId', zoneId);
+    polygon.set('label', `Zone ${this.nextZoneIndex - 1}`);
+
+    this.makePolygonEditable(polygon);
+
+    this.canvas.add(polygon);
+    this.canvas.setActiveObject(polygon);
+    this.canvas.renderAll();
+    this.syncZonesFromCanvas();
+  }
+
+  removeSelectedZone(): void {
+    if (!this.canvas || !this.selectedZoneId) {
+      return;
+    }
+
+    const object = this.canvas.getObjects().find((item: any) => item.zoneId === this.selectedZoneId);
+    if (object) {
+      this.canvas.remove(object);
+      this.canvas.discardActiveObject();
+      this.canvas.requestRenderAll();
+      this.selectedZoneId = null;
+      this.syncZonesFromCanvas();
+    }
+  }
+
+  onZoneLabelChange(zone: SurfaceZone): void {
+    if (!this.canvas) {
+      return;
+    }
+
+    const object = this.canvas.getObjects().find((item: any) => item.zoneId === zone.id);
+    if (object) {
+      object.set('label', zone.label);
+      this.canvas.requestRenderAll();
+    }
+  }
+
+  selectZone(zone: SurfaceZone): void {
+    if (!this.canvas) {
+      return;
+    }
+
+    const object = this.canvas.getObjects().find((item: any) => item.zoneId === zone.id);
+    if (object) {
+      this.canvas.setActiveObject(object);
+      this.canvas.requestRenderAll();
+      this.selectedZoneId = zone.id;
+    }
+  }
+
+  private syncZonesFromCanvas(): void {
+    if (!this.canvas) {
+      return;
+    }
+
+    const objects = this.canvas.getObjects().filter((item: any) => item.type === 'polygon');
+    const zones: SurfaceZone[] = objects.map((obj: any) => {
+      const zoneId = obj.zoneId ?? `zone-${this.nextZoneIndex++}`;
+      obj.set('zoneId', zoneId);
+      const label = obj.label ?? `Zone ${this.nextZoneIndex - 1}`;
+      obj.set('label', label);
+      const matrix = obj.calcTransformMatrix();
+      const transformedPoints: SurfacePoint[] = obj.points.map((point: any) => {
+        const pointWithOffset = new fabric.Point(point.x - obj.pathOffset.x, point.y - obj.pathOffset.y);
+        const transformed = fabric.util.transformPoint(pointWithOffset, matrix);
+        return {
+          x: Math.round(transformed.x),
+          y: Math.round(transformed.y)
+        };
+      });
+      return {
+        id: zoneId,
+        label,
+        points: transformedPoints
+      };
+    });
+
+    this.zones = zones;
+    if (this.selectedZoneId && !zones.some(zone => zone.id === this.selectedZoneId)) {
+      this.selectedZoneId = null;
+    }
+  }
+
+  private onSelection(event: any): void {
+    const obj = event?.selected?.[0];
+    if (obj && obj.zoneId) {
+      this.selectedZoneId = obj.zoneId;
+    } else {
+      this.selectedZoneId = null;
+    }
+  }
+
+  private makePolygonEditable(polygon: any): void {
+    polygon.hasBorders = false;
+    polygon.cornerStyle = 'circle';
+    polygon.cornerColor = '#0099ff';
+    polygon.controls = polygon.points.reduce((controls: Record<string, any>, _point: any, index: number) => {
+      controls[`p${index}`] = new fabric.Control({
+        positionHandler: (_dim: any, _finalMatrix: any, target: any) => {
+          const point = target.points[index];
+          const matrix = target.calcTransformMatrix();
+          const transformed = fabric.util.transformPoint(
+            new fabric.Point(point.x - target.pathOffset.x, point.y - target.pathOffset.y),
+            matrix
+          );
+          return transformed;
+        },
+        actionHandler: (_eventData: any, transform: any, x: number, y: number) => {
+          const poly = transform.target;
+          const localPoint = poly.toLocalPoint(new fabric.Point(x, y), 'center', 'center');
+          poly.points[index].x = localPoint.x + poly.pathOffset.x;
+          poly.points[index].y = localPoint.y + poly.pathOffset.y;
+          poly.dirty = true;
+          poly.setCoords();
+          poly.canvas?.requestRenderAll();
+          this.syncZonesFromCanvas();
+          return true;
+        },
+        actionName: 'modifyPolygon',
+        cursorStyle: 'pointer'
+      });
+      return controls;
+    }, {});
+  }
+}

--- a/colour-simulator/src/index.html
+++ b/colour-simulator/src/index.html
@@ -12,5 +12,6 @@
 </head>
 <body>
   <app-root></app-root>
+  <script src="https://cdn.jsdelivr.net/npm/fabric@6.0.0/dist/fabric.min.js" defer></script>
 </body>
 </html>

--- a/colour-simulator/src/typings/fabric.d.ts
+++ b/colour-simulator/src/typings/fabric.d.ts
@@ -1,0 +1,1 @@
+declare const fabric: any;


### PR DESCRIPTION
## Summary
- represent surface editor zones as editable polygons backed by multiple x/y points instead of rectangles
- sync polygon vertex coordinates to the zone list and expose them in the UI for easier inspection
- tighten styling and polygon control setup so newly added shapes remain adjustable via Fabric.js handles

## Testing
- `npm run build` *(fails: cannot inline external Material Symbols stylesheet shipped with existing components)*

------
https://chatgpt.com/codex/tasks/task_e_68d6f2c07b048321abe870ddf9a24353