### PR TITLE
Add interactive polygon drawing mode to surface editor

### DIFF
--- a/colour-simulator/src/app/components/surface-editor/surface-editor.component.css
+++ b/colour-simulator/src/app/components/surface-editor/surface-editor.component.css
@@ -53,6 +53,18 @@
   background: linear-gradient(135deg, #ef4444, #dc2626);
 }
 
+.surface-editor__controls .secondary {
+  background: #e5e7eb;
+  color: #1f2937;
+  box-shadow: none;
+}
+
+.surface-editor__controls .secondary:not(:disabled):hover {
+  box-shadow: none;
+  transform: translateY(-1px);
+  background: #d1d5db;
+}
+
 .surface-editor__filename {
   font-size: 0.9rem;
   color: #1f2937;
@@ -70,6 +82,21 @@
   background: #fef3c7;
   color: #92400e;
   border: 1px solid #f59e0b;
+}
+
+.surface-editor__instructions {
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background: #eff6ff;
+  border: 1px dashed rgba(37, 99, 235, 0.35);
+  color: #1d4ed8;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.surface-editor__instructions-count {
+  margin: 0;
+  font-weight: 600;
 }
 
 .surface-editor__workspace {

--- a/colour-simulator/src/app/components/surface-editor/surface-editor.component.html
+++ b/colour-simulator/src/app/components/surface-editor/surface-editor.component.html
@@ -6,11 +6,35 @@
 
   <div class="surface-editor__controls">
     <button type="button" (click)="addPolygonZone()" [disabled]="!canAddZones">Ajouter une zone</button>
-    <button type="button" class="danger" (click)="removeSelectedZone()" [disabled]="!selectedZoneId">Supprimer la zone sélectionnée</button>
+    <button type="button" (click)="finishPolygonCreation()" [disabled]="!canFinishZone">Terminer la zone</button>
+    <button
+      type="button"
+      class="secondary"
+      (click)="cancelPolygonCreation()"
+      [disabled]="!isCreatingZone"
+    >
+      Annuler
+    </button>
+    <button
+      type="button"
+      class="danger"
+      (click)="removeSelectedZone()"
+      [disabled]="!selectedZoneId || isCreatingZone"
+    >
+      Supprimer la zone sélectionnée
+    </button>
     <span class="surface-editor__filename" *ngIf="backgroundName">Image : {{ backgroundName }}</span>
     <span class="surface-editor__hint" *ngIf="!backgroundName && !fabricUnavailable">
       Importez une image personnalisée pour commencer la délimitation.
     </span>
+  </div>
+
+  <div class="surface-editor__instructions" *ngIf="isCreatingZone">
+    <p>
+      Cliquez pour placer les sommets de votre zone personnalisée. Définissez au moins trois points puis utilisez «&nbsp;Terminer
+      la zone&nbsp;» pour fermer le polygone.
+    </p>
+    <p class="surface-editor__instructions-count">Points définis : {{ creationPointsCount }}</p>
   </div>
 
   <p *ngIf="fabricUnavailable" class="surface-editor__warning">


### PR DESCRIPTION
## Summary
- enable an interactive polygon drawing workflow for custom surfaces, including per-point manipulation
- add dedicated controls and helper text for starting, finishing, or cancelling zone creation
- style the new drawing controls and guidance block to match the editor

## Testing
- npm run build *(fails: unable to inline external Google Fonts stylesheet)*

------
https://chatgpt.com/codex/tasks/task_e_68d70b825e508321a0cd7e5f9320fb99