### PR TITLE
Enhance surface editor polygon workflows

### DIFF
--- a/colour-simulator/src/app/components/surface-editor/surface-editor.component.css
+++ b/colour-simulator/src/app/components/surface-editor/surface-editor.component.css
@@ -53,6 +53,18 @@
   background: linear-gradient(135deg, #ef4444, #dc2626);
 }
 
+.surface-editor__controls .secondary {
+  background: #e5e7eb;
+  color: #1f2937;
+  box-shadow: none;
+}
+
+.surface-editor__controls .secondary:not(:disabled):hover {
+  box-shadow: none;
+  transform: translateY(-1px);
+  background: #d1d5db;
+}
+
 .surface-editor__filename {
   font-size: 0.9rem;
   color: #1f2937;
@@ -70,6 +82,25 @@
   background: #fef3c7;
   color: #92400e;
   border: 1px solid #f59e0b;
+}
+
+.surface-editor__instructions {
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background: #eff6ff;
+  border: 1px dashed rgba(37, 99, 235, 0.35);
+  color: #1d4ed8;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.surface-editor__instructions p {
+  margin: 0;
+}
+
+.surface-editor__instructions-count {
+  margin: 0;
+  font-weight: 600;
 }
 
 .surface-editor__workspace {

--- a/colour-simulator/src/app/components/surface-editor/surface-editor.component.html
+++ b/colour-simulator/src/app/components/surface-editor/surface-editor.component.html
@@ -6,12 +6,51 @@
 
   <div class="surface-editor__controls">
     <button type="button" (click)="addPolygonZone()" [disabled]="!canAddZones">Ajouter une zone</button>
-    <button type="button" class="danger" (click)="removeSelectedZone()" [disabled]="!selectedZoneId">Supprimer la zone sélectionnée</button>
+    <button type="button" (click)="finishPolygonCreation()" [disabled]="!canFinishZone">Terminer la zone</button>
+    <button
+      type="button"
+      class="secondary"
+      (click)="removeLastCreationPoint()"
+      [disabled]="!isCreatingZone || !creationPointsCount"
+    >
+      Supprimer le dernier point
+    </button>
+    <button
+      type="button"
+      class="secondary"
+      (click)="cancelPolygonCreation()"
+      [disabled]="!isCreatingZone"
+    >
+      Annuler
+    </button>
+    <button
+      type="button"
+      class="danger"
+      (click)="removeSelectedZone()"
+      [disabled]="!selectedZoneId || isCreatingZone"
+    >
+      Supprimer la zone sélectionnée
+    </button>
     <span class="surface-editor__filename" *ngIf="backgroundName">Image : {{ backgroundName }}</span>
     <span class="surface-editor__hint" *ngIf="!backgroundName && !fabricUnavailable">
       Importez une image personnalisée pour commencer la délimitation.
     </span>
   </div>
+
+  <div class="surface-editor__instructions" *ngIf="isCreatingZone">
+    <p>
+      Cliquez pour placer les sommets de votre zone personnalisée. Définissez au moins trois points puis terminez en cliquant sur
+      le premier sommet ou sur «&nbsp;Terminer la zone&nbsp;».
+    </p>
+    <p>
+      Double-cliquez ou appuyez sur Entrée pour fermer la zone. Utilisez «&nbsp;Supprimer le dernier point&nbsp;» ou la touche
+      Retour arrière pour corriger.
+    </p>
+    <p class="surface-editor__instructions-count">Points définis : {{ creationPointsCount }}</p>
+  </div>
+  <p class="surface-editor__hint" *ngIf="zones.length && !isCreatingZone">
+    Conseil : sélectionnez une zone puis faites glisser ses sommets pour ajuster précisément le contour.
+  </p>
 
   <p *ngIf="fabricUnavailable" class="surface-editor__warning">
     Fabric.js n'a pas pu être chargé. Vérifiez votre connexion réseau ou ajoutez la bibliothèque au projet pour activer l'éditeur.

--- a/colour-simulator/src/app/components/surface-editor/surface-editor.component.ts
+++ b/colour-simulator/src/app/components/surface-editor/surface-editor.component.ts
@@ -34,6 +34,16 @@ export class SurfaceEditorComponent implements AfterViewInit, OnChanges, OnDestr
   private pendingBackgroundUrl: string | null = null;
   private pendingZones: CustomSurfaceZone[] | null = null;
   private isRestoringZones = false;
+  isCreatingZone = false;
+  private creationPoints: { x: number; y: number }[] = [];
+  private creationPreviewPoint: { x: number; y: number } | null = null;
+  private creationPolyline?: any;
+  private creationPointMarkers: any[] = [];
+  private creationStartMarker?: any;
+  private readonly canvasClickHandler = (event: any) => this.handleCanvasClick(event);
+  private readonly canvasMoveHandler = (event: any) => this.handleCanvasMove(event);
+  private readonly canvasDoubleClickHandler = (event: any) => this.handleCanvasDoubleClick(event);
+  private readonly keyDownHandler = (event: KeyboardEvent) => this.handleKeyDown(event);
 
   ngAfterViewInit(): void {
     if (typeof fabric === 'undefined') {
@@ -83,6 +93,8 @@ export class SurfaceEditorComponent implements AfterViewInit, OnChanges, OnDestr
   }
 
   ngOnDestroy(): void {
+    this.cancelPolygonCreation();
+    this.detachCreationListeners();
     this.canvas?.dispose();
   }
 
@@ -91,7 +103,15 @@ export class SurfaceEditorComponent implements AfterViewInit, OnChanges, OnDestr
   }
 
   get canAddZones(): boolean {
-    return this.isCanvasReady && !!this.customSurface?.imageDataUrl;
+    return this.isCanvasReady && !!this.customSurface?.imageDataUrl && !this.isCreatingZone;
+  }
+
+  get canFinishZone(): boolean {
+    return this.isCreatingZone && this.creationPoints.length >= 3;
+  }
+
+  get creationPointsCount(): number {
+    return this.creationPoints.length;
   }
 
   addPolygonZone(): void {
@@ -99,15 +119,21 @@ export class SurfaceEditorComponent implements AfterViewInit, OnChanges, OnDestr
       return;
     }
 
-    const zoneId = `zone-${this.nextZoneIndex++}`;
-    const points = [
-      { x: 100, y: 100 },
-      { x: 260, y: 100 },
-      { x: 260, y: 200 },
-      { x: 100, y: 200 }
-    ];
+    if (this.isCreatingZone) {
+      return;
+    }
 
-    const polygon = new fabric.Polygon(points, {
+    this.startPolygonCreation();
+  }
+
+  finishPolygonCreation(): void {
+    if (!this.canvas || !this.canFinishZone) {
+      return;
+    }
+
+    const zoneId = `zone-${this.nextZoneIndex++}`;
+    const polygonPoints = this.creationPoints.map((point) => ({ ...point }));
+    const polygon = new fabric.Polygon(polygonPoints, {
       fill: 'rgba(0, 153, 255, 0.25)',
       stroke: '#0099ff',
       strokeWidth: 2,
@@ -121,15 +147,7 @@ export class SurfaceEditorComponent implements AfterViewInit, OnChanges, OnDestr
       lockScalingY: true
     });
 
-    polygon.set('zoneId', zoneId);
-    polygon.set('label', `Zone ${this.nextZoneIndex - 1}`);
-
-    this.makePolygonEditable(polygon);
-
-    this.canvas.add(polygon);
-    this.canvas.setActiveObject(polygon);
-    this.canvas.renderAll();
-    this.syncZonesFromCanvas();
+    this.finalizePolygon(polygon, zoneId);
   }
 
   removeSelectedZone(): void {
@@ -249,33 +267,67 @@ export class SurfaceEditorComponent implements AfterViewInit, OnChanges, OnDestr
     polygon.hasBorders = false;
     polygon.cornerStyle = 'circle';
     polygon.cornerColor = '#0099ff';
+    polygon.hasControls = true;
+    polygon.hasRotatingPoint = false;
+    polygon.objectCaching = false;
+    polygon.perPixelTargetFind = true;
     polygon.controls = polygon.points.reduce((controls: Record<string, any>, _point: any, index: number) => {
-      controls[`p${index}`] = new fabric.Control({
-        positionHandler: (_dim: any, _finalMatrix: any, target: any) => {
-          const point = target.points[index];
-          const matrix = target.calcTransformMatrix();
-          const transformed = fabric.util.transformPoint(
-            new fabric.Point(point.x - target.pathOffset.x, point.y - target.pathOffset.y),
-            matrix
-          );
-          return transformed;
-        },
-        actionHandler: (_eventData: any, transform: any, x: number, y: number) => {
-          const poly = transform.target;
-          const localPoint = poly.toLocalPoint(new fabric.Point(x, y), 'center', 'center');
-          poly.points[index].x = localPoint.x + poly.pathOffset.x;
-          poly.points[index].y = localPoint.y + poly.pathOffset.y;
-          poly.dirty = true;
-          poly.setCoords();
-          poly.canvas?.requestRenderAll();
-          this.syncZonesFromCanvas();
-          return true;
-        },
-        actionName: 'modifyPolygon',
-        cursorStyle: 'pointer'
-      });
+      controls[`p${index}`] = this.createVertexControl(index);
       return controls;
     }, {});
+    polygon.setCoords();
+  }
+
+  private createVertexControl(index: number): any {
+    return new fabric.Control({
+      positionHandler: (_dim: any, _finalMatrix: any, target: any) => {
+        const point = target.points[index];
+        const localPoint = new fabric.Point(point.x - target.pathOffset.x, point.y - target.pathOffset.y);
+        const matrix = target.calcTransformMatrix();
+        const viewportTransform = target.canvas?.viewportTransform ?? [1, 0, 0, 1, 0, 0];
+        const finalMatrix = fabric.util.multiplyTransformMatrices(viewportTransform, matrix);
+        return fabric.util.transformPoint(localPoint, finalMatrix);
+      },
+      actionHandler: (_eventData: any, transform: any, x: number, y: number) => {
+        const poly = transform.target;
+        const localPoint = poly.toLocalPoint(new fabric.Point(x, y), 'center', 'center');
+        poly.points[index].x = localPoint.x + poly.pathOffset.x;
+        poly.points[index].y = localPoint.y + poly.pathOffset.y;
+        poly.dirty = true;
+        poly.setCoords();
+        poly.canvas?.requestRenderAll();
+        this.syncZonesFromCanvas();
+        return true;
+      },
+      actionName: 'modifyPolygon',
+      cursorStyle: 'pointer',
+      render: this.renderVertexControl,
+      pointIndex: index
+    });
+  }
+
+  private readonly renderVertexControl = (
+    ctx: CanvasRenderingContext2D,
+    left: number,
+    top: number,
+    _styleOverride: any,
+    fabricObject: any
+  ): void => {
+    const zoom = fabricObject.canvas?.getZoom() ?? 1;
+    const size = 10 / zoom;
+    ctx.save();
+    ctx.translate(left, top);
+    ctx.rotate(fabric.util.degreesToRadians(fabricObject.angle ?? 0));
+    ctx.fillStyle = '#ffffff';
+    ctx.strokeStyle = '#1d4ed8';
+    ctx.lineWidth = 2 / zoom;
+    const half = size / 2;
+    ctx.beginPath();
+    ctx.rect(-half, -half, size, size);
+    ctx.fill();
+    ctx.stroke();
+    ctx.restore();
+  };
   }
 
   private handleCustomSurfaceChange(customSurface: CustomSurfaceData | null): void {
@@ -285,6 +337,8 @@ export class SurfaceEditorComponent implements AfterViewInit, OnChanges, OnDestr
       this.pendingZones = customSurface?.zones ?? null;
       return;
     }
+
+    this.cancelPolygonCreation();
 
     if (!customSurface || !customSurface.imageDataUrl) {
       this.clearCanvas();
@@ -329,6 +383,7 @@ export class SurfaceEditorComponent implements AfterViewInit, OnChanges, OnDestr
     if (!this.canvas) {
       return;
     }
+    this.cancelPolygonCreation();
     this.canvas.setBackgroundImage(undefined, this.canvas.renderAll.bind(this.canvas));
     this.backgroundUrl = null;
     this.zones = [];
@@ -346,6 +401,7 @@ export class SurfaceEditorComponent implements AfterViewInit, OnChanges, OnDestr
       return;
     }
 
+    this.cancelPolygonCreation();
     this.isRestoringZones = true;
     const existingPolygons = this.canvas
       .getObjects()
@@ -414,5 +470,331 @@ export class SurfaceEditorComponent implements AfterViewInit, OnChanges, OnDestr
     } else if (zones.length === 0) {
       this.nextZoneIndex = 1;
     }
+  }
+
+  cancelPolygonCreation(): void {
+    if (!this.isCreatingZone) {
+      return;
+    }
+    this.detachCreationListeners();
+    this.clearCreationArtifacts();
+    this.creationPoints = [];
+    this.creationPreviewPoint = null;
+    this.isCreatingZone = false;
+    this.restoreCanvasInteraction();
+    this.canvas?.requestRenderAll();
+  }
+
+  private startPolygonCreation(): void {
+    if (!this.canvas) {
+      return;
+    }
+
+    this.isCreatingZone = true;
+    this.creationPoints = [];
+    this.creationPreviewPoint = null;
+    this.clearCreationArtifacts();
+    this.canvas.discardActiveObject();
+    this.selectedZoneId = null;
+    this.canvas.requestRenderAll();
+    this.canvas.selection = false;
+    this.canvas.defaultCursor = 'crosshair';
+    this.togglePolygonSelectability(false);
+    this.canvas.on('mouse:down', this.canvasClickHandler);
+    this.canvas.on('mouse:move', this.canvasMoveHandler);
+    this.canvas.on('mouse:dblclick', this.canvasDoubleClickHandler);
+    if (typeof window !== 'undefined') {
+      window.addEventListener('keydown', this.keyDownHandler);
+    }
+  }
+
+  private finalizePolygon(polygon: any, zoneId: string): void {
+    if (!this.canvas) {
+      return;
+    }
+
+    polygon.set('zoneId', zoneId);
+    polygon.set('label', `Zone ${this.nextZoneIndex - 1}`);
+
+    this.makePolygonEditable(polygon);
+
+    this.canvas.add(polygon);
+    this.canvas.setActiveObject(polygon);
+
+    this.detachCreationListeners();
+    this.clearCreationArtifacts();
+    this.creationPoints = [];
+    this.creationPreviewPoint = null;
+    this.isCreatingZone = false;
+    this.restoreCanvasInteraction();
+
+    this.canvas.requestRenderAll();
+    this.selectedZoneId = zoneId;
+    this.syncZonesFromCanvas();
+  }
+
+  private handleCanvasClick(event: any): void {
+    if (!this.canvas || !this.isCreatingZone) {
+      return;
+    }
+
+    const pointer = this.canvas.getPointer(event.e);
+    const point = {
+      x: Math.round(pointer.x),
+      y: Math.round(pointer.y)
+    };
+
+    if (this.isPointerNearFirstPoint(point) && this.canFinishZone) {
+      event?.e?.preventDefault?.();
+      event?.e?.stopPropagation?.();
+      this.finishPolygonCreation();
+      return;
+    }
+
+    this.creationPoints.push(point);
+    this.addCreationMarker(point);
+    this.updateCreationShape();
+  }
+
+  private handleCanvasMove(event: any): void {
+    if (!this.canvas || !this.isCreatingZone || !this.creationPoints.length) {
+      return;
+    }
+
+    const pointer = this.canvas.getPointer(event.e);
+    const previewPoint = {
+      x: Math.round(pointer.x),
+      y: Math.round(pointer.y)
+    };
+
+    if (this.isPointerNearFirstPoint(previewPoint) && this.canFinishZone) {
+      this.creationPreviewPoint = { ...this.creationPoints[0] };
+      this.canvas.defaultCursor = 'pointer';
+    } else {
+      this.creationPreviewPoint = previewPoint;
+      this.canvas.defaultCursor = 'crosshair';
+    }
+    this.updateCreationShape();
+  }
+
+  private updateCreationShape(): void {
+    if (!this.canvas) {
+      return;
+    }
+
+    const points = [...this.creationPoints];
+    if (this.creationPreviewPoint) {
+      points.push(this.creationPreviewPoint);
+    }
+
+    if (points.length < 2) {
+      if (this.creationPolyline) {
+        this.canvas.remove(this.creationPolyline);
+        this.creationPolyline = undefined;
+      }
+      this.canvas.requestRenderAll();
+      return;
+    }
+
+    if (!this.creationPolyline) {
+      this.creationPolyline = new fabric.Polyline(points, {
+        fill: 'rgba(37, 99, 235, 0.12)',
+        stroke: '#2563eb',
+        strokeWidth: 2,
+        selectable: false,
+        evented: false,
+        objectCaching: false
+      });
+      this.canvas.add(this.creationPolyline);
+      this.creationPolyline.moveTo(0);
+    } else {
+      this.creationPolyline.set({ points });
+    }
+
+    this.canvas.requestRenderAll();
+  }
+
+  private addCreationMarker(point: { x: number; y: number }): void {
+    if (!this.canvas) {
+      return;
+    }
+
+    const marker = new fabric.Circle({
+      radius: 5,
+      fill: '#2563eb',
+      stroke: '#ffffff',
+      strokeWidth: 2,
+      left: point.x,
+      top: point.y,
+      originX: 'center',
+      originY: 'center',
+      selectable: false,
+      evented: false
+    });
+
+    if (this.creationPoints.length === 1) {
+      marker.set({
+        radius: 6,
+        fill: '#ffffff',
+        stroke: '#2563eb',
+        strokeWidth: 2.5
+      });
+      this.creationStartMarker = marker;
+    }
+
+    this.creationPointMarkers.push(marker);
+    this.canvas.add(marker);
+    marker.moveTo(this.canvas.getObjects().length - 1);
+    this.canvas.requestRenderAll();
+  }
+
+  private clearCreationArtifacts(): void {
+    if (!this.canvas) {
+      return;
+    }
+
+    if (this.creationPolyline) {
+      this.canvas.remove(this.creationPolyline);
+      this.creationPolyline = undefined;
+    }
+
+    if (this.creationPointMarkers.length) {
+      this.creationPointMarkers.forEach((marker) => this.canvas?.remove(marker));
+      this.creationPointMarkers = [];
+    }
+
+    if (this.creationStartMarker) {
+      if (this.creationStartMarker.canvas) {
+        this.canvas.remove(this.creationStartMarker);
+      }
+      this.creationStartMarker = undefined;
+    }
+  }
+
+  private detachCreationListeners(): void {
+    if (!this.canvas) {
+      return;
+    }
+
+    this.canvas.off('mouse:down', this.canvasClickHandler);
+    this.canvas.off('mouse:move', this.canvasMoveHandler);
+    this.canvas.off('mouse:dblclick', this.canvasDoubleClickHandler);
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('keydown', this.keyDownHandler);
+    }
+  }
+
+  private restoreCanvasInteraction(): void {
+    if (!this.canvas) {
+      return;
+    }
+
+    this.canvas.selection = true;
+    this.canvas.defaultCursor = 'default';
+    this.togglePolygonSelectability(true);
+  }
+
+  private togglePolygonSelectability(enabled: boolean): void {
+    if (!this.canvas) {
+      return;
+    }
+
+    this.canvas.getObjects().forEach((obj: any) => {
+      if (obj.type === 'polygon') {
+        obj.selectable = enabled;
+        obj.evented = enabled;
+      }
+    });
+  }
+
+  removeLastCreationPoint(): void {
+    if (!this.canvas || !this.isCreatingZone || !this.creationPoints.length) {
+      return;
+    }
+
+    this.creationPoints.pop();
+    const marker = this.creationPointMarkers.pop();
+    if (marker) {
+      this.canvas.remove(marker);
+      if (marker === this.creationStartMarker) {
+        this.creationStartMarker = undefined;
+      }
+    }
+
+    if (!this.creationPoints.length && this.creationStartMarker) {
+      this.canvas.remove(this.creationStartMarker);
+      this.creationStartMarker = undefined;
+    }
+
+    this.creationPreviewPoint = null;
+    this.updateCreationShape();
+    this.canvas.defaultCursor = 'crosshair';
+    this.canvas.requestRenderAll();
+  }
+
+  private handleCanvasDoubleClick(event: any): void {
+    if (!this.canvas || !this.isCreatingZone) {
+      return;
+    }
+
+    event?.e?.preventDefault?.();
+    event?.e?.stopPropagation?.();
+
+    if (this.creationPoints.length >= 2) {
+      const lastIndex = this.creationPoints.length - 1;
+      const lastPoint = this.creationPoints[lastIndex];
+      const previousPoint = this.creationPoints[lastIndex - 1];
+      if (lastPoint && previousPoint) {
+        const distance = Math.hypot(lastPoint.x - previousPoint.x, lastPoint.y - previousPoint.y);
+        if (distance <= 2) {
+          this.creationPoints.pop();
+          const marker = this.creationPointMarkers.pop();
+          if (marker) {
+            this.canvas.remove(marker);
+            if (marker === this.creationStartMarker) {
+              this.creationStartMarker = undefined;
+            }
+          }
+          this.creationPreviewPoint = null;
+        }
+      }
+    }
+
+    if (this.canFinishZone) {
+      this.finishPolygonCreation();
+    }
+  }
+
+  private handleKeyDown(event: KeyboardEvent): void {
+    if (!this.isCreatingZone) {
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      this.cancelPolygonCreation();
+      return;
+    }
+
+    if ((event.key === 'Backspace' || event.key === 'Delete') && this.creationPoints.length) {
+      event.preventDefault();
+      this.removeLastCreationPoint();
+      return;
+    }
+
+    if ((event.key === 'Enter' || event.key === ' ') && this.canFinishZone) {
+      event.preventDefault();
+      this.finishPolygonCreation();
+    }
+  }
+
+  private isPointerNearFirstPoint(point: { x: number; y: number }): boolean {
+    if (!this.creationPoints.length) {
+      return false;
+    }
+
+    const firstPoint = this.creationPoints[0];
+    const distance = Math.hypot(point.x - firstPoint.x, point.y - firstPoint.y);
+    return distance <= 12;
   }
 }


### PR DESCRIPTION
## Summary
- add keyboard shortcuts, double-click closing, and undo support to the custom surface polygon creation flow
- render custom draggable vertex handles for finished polygons so contours can be reshaped precisely
- expand the UI with additional guidance, feedback, and controls while drawing zones

## Testing
- not run (Angular dependencies are not installed in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d70b825e508321a0cd7e5f9320fb99